### PR TITLE
Security groups needs configuring

### DIFF
--- a/vpc.yaml
+++ b/vpc.yaml
@@ -144,6 +144,23 @@ Resources:
         - Key: "Name"
           Value: "BastianHost"
 
+  PrivateEC2Instance1A:
+    Type: "AWS::EC2::Instance"
+    Properties:
+      InstanceType: "t2.micro"
+      ImageId: "ami-0dfdc165e7af15242"
+      KeyName: "EC2_Tutorial"
+      NetworkInterfaces:
+        - AssociatePublicIpAddress: true
+          DeviceIndex: 0
+          DeleteOnTermination: true
+          SubnetId: !Ref AppSubnet1A
+          GroupSet:
+            - !Ref MySecurityGroup
+      Tags:
+        - Key: "Name"
+          Value: "PrivateEC2Instance1A"
+
   #security group for bastian host
   MySecurityGroup:
     Type: "AWS::EC2::SecurityGroup"

--- a/vpc.yaml
+++ b/vpc.yaml
@@ -156,7 +156,7 @@ Resources:
           DeleteOnTermination: true
           SubnetId: !Ref AppSubnet1A
           GroupSet:
-            - !Ref MySecurityGroup
+            - !Ref MySecurityGroupForPrivateEc2Instance
       Tags:
         - Key: "Name"
           Value: "PrivateEC2Instance1A"
@@ -176,3 +176,21 @@ Resources:
       Tags:
         - Key: "Name"
           Value: "MySecurityGroup"
+
+  #create another security group this will be associated
+  #with the private ec2 instance
+
+  MySecurityGroupForPrivateEc2Instance:
+    Type: "AWS::EC2::SecurityGroup"
+    Properties:
+      GroupName: "MySecurityGroupForPrivateEc2Instance"
+      GroupDescription: "My Security group for private ec2 instance"
+      VpcId: !Ref MyVPC
+      SecurityGroupIngress:
+        - IpProtocol: icmp
+          FromPort: -1
+          ToPort: -1
+          SourceSecurityGroupId: !Ref MySecurityGroup
+      Tags:
+        - Key: "Name"
+          Value: "MySecurityGroupForPrivateEc2Instance"

--- a/vpc.yaml
+++ b/vpc.yaml
@@ -155,7 +155,7 @@ Resources:
         - IpProtocol: tcp
           FromPort: 22
           ToPort: 22
-          CidrIp: 0.0.0.0/0
+          CidrIp: 18.202.216.48/29
       Tags:
         - Key: "Name"
           Value: "MySecurityGroup"

--- a/vpc.yaml
+++ b/vpc.yaml
@@ -139,58 +139,104 @@ Resources:
           DeleteOnTermination: true
           SubnetId: !Ref PublicSubnet1A
           GroupSet:
-            - !Ref MySecurityGroup
+            - !Ref BastianSG
       Tags:
         - Key: "Name"
           Value: "BastianHost"
 
-  PrivateEC2Instance1A:
-    Type: "AWS::EC2::Instance"
-    Properties:
-      InstanceType: "t2.micro"
-      ImageId: "ami-0dfdc165e7af15242"
-      KeyName: "EC2_Tutorial"
-      NetworkInterfaces:
-        - AssociatePublicIpAddress: true
-          DeviceIndex: 0
-          DeleteOnTermination: true
-          SubnetId: !Ref AppSubnet1A
-          GroupSet:
-            - !Ref MySecurityGroupForPrivateEc2Instance
-      Tags:
-        - Key: "Name"
-          Value: "PrivateEC2Instance1A"
-
-  #security group for bastian host
-  MySecurityGroup:
+    #security group for bastian host
+  BastianSG:
     Type: "AWS::EC2::SecurityGroup"
     Properties:
-      GroupName: "MySecurityGroup"
-      GroupDescription: "My Security group"
+      GroupName: "BastianSecurityGroup"
+      GroupDescription: "Enable SSH Access"
       VpcId: !Ref MyVPC
       SecurityGroupIngress:
+        - IpProtocol: tcp
+          FromPort: 22
+          ToPort: 22
+          CidrIp: 31.94.66.143/32
         - IpProtocol: tcp
           FromPort: 22
           ToPort: 22
           CidrIp: 18.202.216.48/29
       Tags:
         - Key: "Name"
-          Value: "MySecurityGroup"
+          Value: "BastianSG"
 
-  #create another security group this will be associated
-  #with the private ec2 instance
+  #instance for app subnet
+  AppInstance:
+    Type: "AWS::EC2::Instance"
+    Properties:
+      InstanceType: "t2.micro"
+      ImageId: "ami-0dfdc165e7af15242"
+      NetworkInterfaces:
+        - AssociatePublicIpAddress: true
+          DeviceIndex: 0
+          DeleteOnTermination: true
+          SubnetId: !Ref AppSubnet1A
+          GroupSet:
+            - !Ref AppSG
+      Tags:
+        - Key: "Name"
+          Value: "AppInstance"
 
-  MySecurityGroupForPrivateEc2Instance:
+  #security group for app instance
+  AppSG:
     Type: "AWS::EC2::SecurityGroup"
     Properties:
-      GroupName: "MySecurityGroupForPrivateEc2Instance"
-      GroupDescription: "My Security group for private ec2 instance"
+      GroupName: "AppSecurityGroup"
+      GroupDescription: "allow ssh from bastian"
+      VpcId: !Ref MyVPC
+      SecurityGroupIngress:
+        - IpProtocol: tcp
+          FromPort: 22
+          ToPort: 22
+          SourceSecurityGroupId: !Ref BastianSG
+        - IpProtocol: tcp
+          FromPort: 22
+          ToPort: 22
+          CidrIp: 18.202.216.48/29
+        - IpProtocol: icmp
+          FromPort: -1
+          ToPort: -1
+      Tags:
+        - Key: "Name"
+          Value: "AppSG"
+
+  #instance for database subnet
+  DataInstance:
+    Type: "AWS::EC2::Instance"
+    Properties:
+      InstanceType: "t2.micro"
+      ImageId: "ami-0dfdc165e7af15242"
+      NetworkInterfaces:
+        - AssociatePublicIpAddress: true
+          DeviceIndex: 0
+          DeleteOnTermination: true
+          SubnetId: !Ref DatabaseSubnet1A
+          GroupSet:
+            - !Ref DatabaseSG
+      Tags:
+        - Key: "Name"
+          Value: "DatabaseInstance"
+
+  #security group for database instance
+  DatabaseSG:
+    Type: "AWS::EC2::SecurityGroup"
+    Properties:
+      GroupName: "DatabaseSecurityGroup"
+      GroupDescription: "allow ping from app subnet"
       VpcId: !Ref MyVPC
       SecurityGroupIngress:
         - IpProtocol: icmp
           FromPort: -1
           ToPort: -1
-          SourceSecurityGroupId: !Ref MySecurityGroup
+          SourceSecurityGroupId: !Ref AppSG
+        - IpProtocol: tcp
+          FromPort: 22
+          ToPort: 22
+          CidrIp: 18.202.216.48/29
       Tags:
         - Key: "Name"
-          Value: "MySecurityGroupForPrivateEc2Instance"
+          Value: "DatabaseSG"


### PR DESCRIPTION
The network subnets are operational, yet encountering issues with login due to permission denial, likely stemming from a mismatched IP address within the security group configuration. This discrepancy arises as I'm utilizing a hotspot at work. Rectification requires adjustment of security group settings to align with the appropriate IP, a task I'll address when in a more conducive environment, such as at home. Tomorrow's priority lies in updating the security groups to ensure seamless functionality. If necessary, exploring an alternate availability zone within the Ireland region may offer a solution in compliance with specified IP requirements.