### PR TITLE
Tag EC2 instances as Bastion

### DIFF
--- a/cea_cloudformation/ec2.yaml
+++ b/cea_cloudformation/ec2.yaml
@@ -11,7 +11,7 @@ Resources:
   MyVPC:
     Type: AWS::EC2::VPC
     Properties:
-      CidrBlock: 172.16.16.0/16
+      CidrBlock: 172.16.0.0/16
       EnableDnsSupport: "true"
       EnableDnsHostnames: "true"
       Tags:
@@ -184,7 +184,7 @@ Resources:
             - !Ref WebServerSecurityGroup
       Tags:
         - Key: Name
-          Value: WebServerInstance1A
+          Value: Bastion
       UserData: !Base64
         Fn::Sub: |
           #!/bin/bash
@@ -211,7 +211,7 @@ Resources:
             - !Ref WebServerSecurityGroup
       Tags:
         - Key: Name
-          Value: WebServerInstance1B
+          Value: Bastion
       UserData: !Base64
         Fn::Sub: |
           #!/bin/bash


### PR DESCRIPTION
## Summary
- Tag EC2 instances with Name: Bastion in CloudFormation template
- Correct VPC CIDR block to satisfy cfn-lint

## Testing
- `cfn-lint cea_cloudformation/ec2.yaml`

------
https://chatgpt.com/codex/tasks/task_e_68a1b44fd1bc8330bd0b3e5e6acd79ae