### PR TITLE
docs: clarify TravelEase project structure

### DIFF
--- a/Portfolio_projects/TravelEase/README.md
+++ b/Portfolio_projects/TravelEase/README.md
@@ -1,13 +1,37 @@
-Portfolio Project:
+## TravelEase
 
-Introduction:
-This portfolio project will focus on creating a form for travelling. This should allow customers to book flights with ease. we are going to be using Amplify for the front end and we will be using lamaba for the servverless functionalities.
+TravelEase is a simple travel booking prototype. It provides an easy way for users to submit flight requests and is built with a serverless mindset.
 
-Prerequisites:
+## Project Structure
+
+- **amplify/** – Frontend application managed by AWS Amplify.
+- **travel_backend/** – Backend infrastructure defined using the AWS Cloud Development Kit (CDK).
+
+## Prerequisites
+
 - Node.js installed on your machine
-- AWS account with Amplify CLI installed
-- AWS Lambda function set up
-- aws cdk for deployment
+- AWS account with Amplify CLI configured
+- AWS CDK CLI
 
-System Design:
+## Getting Started
+
+### Frontend
+
+```
+cd amplify
+npm install
+npm start
+```
+
+### Backend
+
+```
+cd travel_backend
+npm install
+npm run build
+cdk deploy
+```
+
+## System Design
+
 ![Contact Form GIF](system_design/contact_form.gif)


### PR DESCRIPTION
## Summary
- expand TravelEase README with clearer intro and layout
- document frontend Amplify app and CDK backend folders
- add setup instructions for each component

## Testing
- `npm test` (TravelEase) *(fails: no test specified)*
- `npm test` (TravelEase/travel_backend)`

------
https://chatgpt.com/codex/tasks/task_e_68c685b25c248330aab184497bc54f5c