### PR TITLE
Add SNS notifications and bounce handling to TravelEase backend

### DIFF
--- a/Portfolio_projects/TravelEase/travel_backend/.gitignore
+++ b/Portfolio_projects/TravelEase/travel_backend/.gitignore
@@ -1,3 +1,5 @@
+!lib/
+!lib/**/*.ts
 *.js
 !jest.config.js
 *.d.ts

--- a/Portfolio_projects/TravelEase/travel_backend/bin/travel_backend.ts
+++ b/Portfolio_projects/TravelEase/travel_backend/bin/travel_backend.ts
@@ -5,27 +5,16 @@ import { SesStack } from "../lib/ses-stack";
 
 const app = new cdk.App();
 
-// Deploy SES stack first
+const notificationEmail = "ceesay.ml@outlook.com";
+
 const sesStack = new SesStack(app, "SesStack", {
-  /* Uncomment the next line to specialize this stack for the AWS Account
-   * and Region that are implied by the current CLI configuration. */
-  // env: { account: process.env.CDK_DEFAULT_ACCOUNT, region: process.env.CDK_DEFAULT_REGION },
+  emailAddress: notificationEmail,
 });
 
-// Deploy TravelBackend stack with dependency on SES stack
 const travelBackendStack = new TravelBackendStack(app, "TravelBackendStack", {
   emailIdentity: sesStack.emailIdentity,
   emailAddress: sesStack.emailAddress,
-  /* Uncomment the next line to specialize this stack for the AWS Account
-   * and Region that are implied by the current CLI configuration. */
-  // env: { account: process.env.CDK_DEFAULT_ACCOUNT, region: process.env.CDK_DEFAULT_REGION },
-
-  /* Uncomment the next line if you know exactly what Account and Region you
-   * want to deploy the stack to. */
-  // env: { account: '123456789012', region: 'us-east-1' },
-
-  /* For more information, see https://docs.aws.amazon.com/cdk/latest/guide/environments.html */
+  notificationEmail,
 });
 
-// Explicitly add dependency to ensure SES stack deploys first
 travelBackendStack.addDependency(sesStack);

--- a/Portfolio_projects/TravelEase/travel_backend/lambda/app.py
+++ b/Portfolio_projects/TravelEase/travel_backend/lambda/app.py
@@ -1,167 +1,232 @@
-import json
-import boto3
-import os
 import base64
+import json
+import os
 import uuid
+from datetime import datetime, timezone
 
-# import requests
+import boto3
+
+sqs = boto3.client("sqs")
+ses = boto3.client("ses")
+sns = boto3.client("sns")
+dynamodb = boto3.resource("dynamodb")
+
+table_name = os.environ.get("TABLE_NAME")
+queue_url = os.environ.get("QUEUE_URL")
+source_email = os.environ.get("SOURCE_EMAIL")
+owner_email = os.environ.get("OWNER_EMAIL", source_email)
+business_email = os.environ.get("BUSINESS_EMAIL", owner_email)
+sns_topic_arn = os.environ.get("SNS_TOPIC_ARN")
+ses_configuration_set = os.environ.get("SES_CONFIGURATION_SET")
+
+table = dynamodb.Table(table_name) if table_name else None
 
 
-def lambda_handler(event, context):
-    """Lambda function that processes form input and sends to SQS and SES
+class BadRequestError(ValueError):
+    """Raised when the incoming payload is invalid."""
 
-    Parameters
-    ----------
-    event: dict, required
-        API Gateway Lambda Proxy Input Format
 
-    context: object, required
-        Lambda Context runtime methods and attributes
+def _load_body(event: dict) -> dict:
+    """Extract and decode the JSON body from the API Gateway event."""
 
-    Returns
-    ------
-    API Gateway Lambda Proxy Output Format: dict
-    """
+    body = event.get("body", "")
+    if isinstance(body, (bytes, bytearray)):
+        body = body.decode("utf-8")
+
+    if event.get("isBase64Encoded"):
+        body = base64.b64decode(body).decode("utf-8")
+
+    if not body:
+        raise BadRequestError("Request body is required.")
 
     try:
-        # Parse the body
-        if 'body' in event:
-            if event.get('isBase64Encoded', False):
-                body = base64.b64decode(event['body']).decode('utf-8')
-            else:
-                body = event['body']
-            # Prepare emails: customer receipt and owner notification
-            # Customer receipt email
-            customer_email_subject = f"Thank you for your submission, {form_data['name']}"
-            customer_email_text = f"""Hello {form_data['name']},
+        payload = json.loads(body)
+    except json.JSONDecodeError as exc:
+        raise BadRequestError("Request body must be valid JSON.") from exc
 
-    Thank you for contacting TravelEase. We received your submission (ID: {form_data['submission_id']}).
-    Here are the details:
-    - Name: {form_data['name']}
-    - Email: {form_data['email']}
-    - Phone: {form_data['phone']}
-    - Inquiry Type: {form_data['inquiry_type']}
-    - Message: {form_data['message']}
-        <body>
-        <h1>New Form Submission</h1>
-        <p><b>Submission ID:</b> {form_data['submission_id']}</p>
-            customer_email_html = f"""<html><body><h1>TravelEase Submission Received</h1><p>Submission ID: {form_data['submission_id']}</p><ul><li>Name: {form_data['name']}</li><li>Email: {form_data['email']}</li><li>Phone: {form_data['phone']}</li><li>Inquiry Type: {form_data['inquiry_type']}</li><li>Message: {form_data['message']}</li></ul></body></html>"""
+    return payload
 
-            ses_customer_response = ses.send_email(
-                Source=source_email,
-                Destination={
-                    'ToAddresses': [form_data['email']],
-                },
-                Message={
-                    'Subject': {
-                        'Data': customer_email_subject
-                    },
-                    'Body': {
-                        'Text': {
-                            'Data': customer_email_text
-                        },
-                        'Html': {
-                            'Data': customer_email_html
-                        }
-                    }
-                }
-            )
 
-            # Owner/Business notification email
-            owner_email = os.environ.get('OWNER_EMAIL', to_email)
-            owner_subject = f"New TravelEase submission from {form_data['name']}"
-            owner_text = f"""A new travel form submission has been received.
-    Submission ID: {form_data['submission_id']}
-    Name: {form_data['name']}
-    Email: {form_data['email']}
-    Phone: {form_data['phone']}
-    Inquiry Type: {form_data['inquiry_type']}
-    Message: {form_data['message']}
-    """
-            owner_html = f"""<html><body><h1>New TravelEase Form Submission</h1><p>Submission ID: {form_data['submission_id']}</p><ul><li>Name: {form_data['name']}</li><li>Email: {form_data['email']}</li><li>Phone: {form_data['phone']}</li><li>Inquiry Type: {form_data['inquiry_type']}</li><li>Message: {form_data['message']}</li></ul></body></html>"""
+def _validate_payload(payload: dict) -> dict:
+    """Validate required fields and construct the form data item."""
 
-            ses_owner_response = ses.send_email(
-                Source=source_email,
-                Destination={
-                    'ToAddresses': [owner_email],
-                },
-                Message={
-                    'Subject': {
-                        'Data': owner_subject
-                    },
-                    'Body': {
-                        'Text': {
-                            'Data': owner_text
-                        },
-                        'Html': {
-                            'Data': owner_html
-                        }
-                    }
-                }
-            )
+    required_fields = ["name", "email", "phone", "inquiry_type", "message"]
+    missing = [field for field in required_fields if not payload.get(field)]
+    if missing:
+        raise BadRequestError(f"Missing required fields: {', '.join(missing)}")
 
-            # Put item in DynamoDB
-            table.put_item(Item=form_data)
+    submission_id = str(uuid.uuid4())
+    timestamp = datetime.now(timezone.utc).isoformat()
 
-            return {
-                "statusCode": 200,
-                "body": json.dumps({
-                    "message": "Form submitted successfully",
-                    "sqs_message_id": sqs_response['MessageId'],
-                    "customer_ses_message_id": ses_customer_response['MessageId'],
-                    "owner_ses_message_id": ses_owner_response['MessageId'],
-                    "business_ses_message_id": ses_business_response['MessageId'],
-                    "submission_id": form_data['submission_id']
-                }),
-            }
+    form_data = {
+        "submission_id": submission_id,
+        "name": payload["name"],
+        "email": payload["email"],
+        "phone": payload["phone"],
+        "inquiry_type": payload["inquiry_type"],
+        "message": payload["message"],
+        "created_at": timestamp,
+    }
+
+    return form_data
+
+
+def _send_sqs_message(form_data: dict) -> dict | None:
+    if not queue_url:
+        return None
+
+    message = json.dumps(form_data)
+    return sqs.send_message(QueueUrl=queue_url, MessageBody=message)
+
+
+def _store_submission(form_data: dict) -> None:
+    if table is None:
+        return
+    table.put_item(Item=form_data)
+
+
+def _build_customer_email(form_data: dict) -> tuple[str, dict]:
+    subject = f"Thank you for your submission, {form_data['name']}"
+    text = (
+        "Hello {name},\n\n"
+        "Thank you for contacting TravelEase. We received your submission (ID: {submission_id}).\n"
+        "Here are the details:\n"
+        "- Name: {name}\n"
+        "- Email: {email}\n"
+        "- Phone: {phone}\n"
+        "- Inquiry Type: {inquiry_type}\n"
+        "- Message: {message}\n"
+    ).format(**form_data)
+
+    html = f"""
+    <html>
+      <body>
+        <h1>TravelEase Submission Received</h1>
+        <p><strong>Submission ID:</strong> {form_data['submission_id']}</p>
         <ul>
-            <li><b>Name:</b> {form_data['name']}</li>
-            <li><b>Email:</b> {form_data['email']}</li>
-            <li><b>Phone:</b> {form_data['phone']}</li>
-            <li><b>Inquiry Type:</b> {form_data['inquiry_type']}</li>
-            <li><b>Message:</b> {form_data['message']}</li>
+          <li><strong>Name:</strong> {form_data['name']}</li>
+          <li><strong>Email:</strong> {form_data['email']}</li>
+          <li><strong>Phone:</strong> {form_data['phone']}</li>
+          <li><strong>Inquiry Type:</strong> {form_data['inquiry_type']}</li>
+          <li><strong>Message:</strong> {form_data['message']}</li>
         </ul>
-        </body>
-        </html>"""
+      </body>
+    </html>
+    """
 
-        ses_business_response = ses.send_email(
-            Source=source_email,
-            Destination={
-                'ToAddresses': [
-                    to_email,
-                ]
-            },
-            Message={
-                'Subject': {
-                    'Data': business_email_subject
-                },
-                'Body': {
-                    'Text': {
-                        'Data': business_email_text
-                    },
-                    'Html': {
-                        'Data': business_email_html
-                    }
-                }
-            }
-        )
+    return subject, {"Text": {"Data": text}, "Html": {"Data": html}}
 
-        # Put item in DynamoDB
-        table.put_item(Item=form_data)
+
+def _build_owner_email(form_data: dict) -> tuple[str, dict]:
+    subject = f"New TravelEase submission from {form_data['name']}"
+    text = (
+        "A new travel form submission has been received.\n\n"
+        "Submission ID: {submission_id}\n"
+        "Name: {name}\n"
+        "Email: {email}\n"
+        "Phone: {phone}\n"
+        "Inquiry Type: {inquiry_type}\n"
+        "Message: {message}\n"
+    ).format(**form_data)
+
+    html = f"""
+    <html>
+      <body>
+        <h1>New TravelEase Form Submission</h1>
+        <p><strong>Submission ID:</strong> {form_data['submission_id']}</p>
+        <ul>
+          <li><strong>Name:</strong> {form_data['name']}</li>
+          <li><strong>Email:</strong> {form_data['email']}</li>
+          <li><strong>Phone:</strong> {form_data['phone']}</li>
+          <li><strong>Inquiry Type:</strong> {form_data['inquiry_type']}</li>
+          <li><strong>Message:</strong> {form_data['message']}</li>
+        </ul>
+      </body>
+    </html>
+    """
+
+    return subject, {"Text": {"Data": text}, "Html": {"Data": html}}
+
+
+def _send_email(recipient: str, subject: str, body: dict) -> dict:
+    if not source_email:
+        raise RuntimeError("SOURCE_EMAIL environment variable is not set.")
+
+    params: dict = {
+        "Source": source_email,
+        "Destination": {"ToAddresses": [recipient]},
+        "Message": {
+            "Subject": {"Data": subject},
+            "Body": body,
+        },
+    }
+
+    if ses_configuration_set:
+        params["ConfigurationSetName"] = ses_configuration_set
+
+    return ses.send_email(**params)
+
+
+def _publish_to_topic(form_data: dict) -> dict | None:
+    if not sns_topic_arn:
+        return None
+
+    message = json.dumps(form_data, default=str)
+    subject = f"TravelEase submission from {form_data['name']}"
+
+    return sns.publish(
+        TopicArn=sns_topic_arn,
+        Subject=subject,
+        Message=message,
+    )
+
+
+def lambda_handler(event, _context):
+    try:
+        payload = _load_body(event)
+        form_data = _validate_payload(payload)
+
+        sqs_response = _send_sqs_message(form_data)
+        _store_submission(form_data)
+
+        customer_subject, customer_body = _build_customer_email(form_data)
+        owner_subject, owner_body = _build_owner_email(form_data)
+
+        customer_email_id = _send_email(form_data["email"], customer_subject, customer_body)
+        owner_email_id = _send_email(owner_email, owner_subject, owner_body)
+
+        business_email_id = None
+        if business_email and business_email != owner_email:
+            business_email_id = _send_email(business_email, owner_subject, owner_body)
+
+        sns_response = _publish_to_topic(form_data)
+
+        response_body = {
+            "message": "Form submitted successfully",
+            "submission_id": form_data["submission_id"],
+            "customer_ses_message_id": customer_email_id.get("MessageId"),
+            "owner_ses_message_id": owner_email_id.get("MessageId"),
+            "business_ses_message_id": business_email_id.get("MessageId") if business_email_id else None,
+            "sqs_message_id": sqs_response.get("MessageId") if sqs_response else None,
+            "sns_message_id": sns_response.get("MessageId") if sns_response else None,
+        }
 
         return {
             "statusCode": 200,
-            "body": json.dumps({
-                "message": "Form submitted successfully",
-                "sqs_message_id": sqs_response['MessageId'],
-                "customer_ses_message_id": ses_customer_response['MessageId'],
-                "business_ses_message_id": ses_business_response['MessageId']
-            }),
+            "body": json.dumps(response_body),
+            "headers": {"Content-Type": "application/json"},
         }
 
-    except Exception as e:
-        print(e)
+    except BadRequestError as exc:
+        return {
+            "statusCode": 400,
+            "body": json.dumps({"error": str(exc)}),
+            "headers": {"Content-Type": "application/json"},
+        }
+
+    except Exception as exc:
         return {
             "statusCode": 500,
-            "body": json.dumps({"error": str(e)})
+            "body": json.dumps({"error": str(exc)}),
+            "headers": {"Content-Type": "application/json"},
         }

--- a/Portfolio_projects/TravelEase/travel_backend/lib/ses-stack.ts
+++ b/Portfolio_projects/TravelEase/travel_backend/lib/ses-stack.ts
@@ -1,0 +1,35 @@
+import { Stack, StackProps, CfnOutput } from "aws-cdk-lib";
+import { aws_ses as ses } from "aws-cdk-lib";
+import { Construct } from "constructs";
+
+export interface SesStackProps extends StackProps {
+  readonly emailAddress?: string;
+}
+
+export class SesStack extends Stack {
+  public readonly emailIdentity: ses.EmailIdentity;
+  public readonly emailAddress: string;
+
+  constructor(scope: Construct, id: string, props?: SesStackProps) {
+    super(scope, id, props);
+
+    const emailAddress = props?.emailAddress ?? "ceesay.ml@outlook.com";
+    this.emailAddress = emailAddress;
+
+    this.emailIdentity = new ses.EmailIdentity(this, "EmailIdentity", {
+      identity: ses.Identity.email(emailAddress),
+    });
+
+    new CfnOutput(this, "SesEmailAddress", {
+      value: emailAddress,
+    });
+
+    new CfnOutput(this, "SesEmailIdentityArn", {
+      value: this.emailIdentity.emailIdentityArn,
+    });
+
+    new CfnOutput(this, "SesEmailIdentityName", {
+      value: this.emailIdentity.emailIdentityName,
+    });
+  }
+}

--- a/Portfolio_projects/TravelEase/travel_backend/lib/travel_backend-stack.ts
+++ b/Portfolio_projects/TravelEase/travel_backend/lib/travel_backend-stack.ts
@@ -1,0 +1,117 @@
+import { Duration, RemovalPolicy, Stack, StackProps, CfnOutput } from "aws-cdk-lib";
+import { aws_apigateway as apigw } from "aws-cdk-lib";
+import { aws_dynamodb as dynamodb } from "aws-cdk-lib";
+import { aws_lambda as lambda } from "aws-cdk-lib";
+import { aws_sns as sns } from "aws-cdk-lib";
+import { aws_sns_subscriptions as subscriptions } from "aws-cdk-lib";
+import { aws_sqs as sqs } from "aws-cdk-lib";
+import { aws_ses as ses } from "aws-cdk-lib";
+import { Construct } from "constructs";
+import * as path from "path";
+
+export interface TravelBackendStackProps extends StackProps {
+  readonly emailIdentity: ses.IEmailIdentity;
+  readonly emailAddress: string;
+  readonly notificationEmail?: string;
+}
+
+export class TravelBackendStack extends Stack {
+  public readonly api: apigw.RestApi;
+  public readonly queue: sqs.Queue;
+  public readonly table: dynamodb.Table;
+  public readonly notificationTopic: sns.Topic;
+  public readonly configurationSet: ses.CfnConfigurationSet;
+
+  constructor(scope: Construct, id: string, props: TravelBackendStackProps) {
+    super(scope, id, props);
+
+    const notificationEmail = props.notificationEmail ?? props.emailAddress;
+
+    this.table = new dynamodb.Table(this, "FormTable", {
+      partitionKey: { name: "submission_id", type: dynamodb.AttributeType.STRING },
+      billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
+      removalPolicy: RemovalPolicy.DESTROY,
+      tableName: "travelease-form",
+    });
+
+    this.queue = new sqs.Queue(this, "FormQueue", {
+      visibilityTimeout: Duration.minutes(5),
+    });
+
+    this.notificationTopic = new sns.Topic(this, "FormSubmissionTopic", {
+      displayName: "TravelEase Form Notifications",
+    });
+
+    this.notificationTopic.addSubscription(
+      new subscriptions.EmailSubscription(notificationEmail)
+    );
+
+    this.configurationSet = new ses.CfnConfigurationSet(this, "TravelEaseConfigSet", {
+      name: "TravelEaseBounceConfig",
+    });
+
+    new ses.CfnConfigurationSetEventDestination(this, "BounceEventDestination", {
+      configurationSetName: this.configurationSet.name ?? this.configurationSet.ref,
+      eventDestination: {
+        name: "BounceAndComplaintNotifications",
+        enabled: true,
+        matchingEventTypes: ["BOUNCE", "COMPLAINT"],
+        snsDestination: {
+          topicArn: this.notificationTopic.topicArn,
+        },
+      },
+    });
+
+    const formHandler = new lambda.Function(this, "FormHandlerFunction", {
+      runtime: lambda.Runtime.PYTHON_3_12,
+      handler: "app.lambda_handler",
+      code: lambda.Code.fromAsset(path.join(__dirname, "../lambda")),
+      timeout: Duration.seconds(30),
+      environment: {
+        TABLE_NAME: this.table.tableName,
+        QUEUE_URL: this.queue.queueUrl,
+        SOURCE_EMAIL: props.emailAddress,
+        OWNER_EMAIL: notificationEmail,
+        BUSINESS_EMAIL: notificationEmail,
+        SNS_TOPIC_ARN: this.notificationTopic.topicArn,
+        SES_CONFIGURATION_SET: this.configurationSet.ref,
+      },
+    });
+
+    this.table.grantWriteData(formHandler);
+    this.queue.grantSendMessages(formHandler);
+    this.notificationTopic.grantPublish(formHandler);
+    props.emailIdentity.grantSendEmail(formHandler);
+
+    this.api = new apigw.RestApi(this, "TravelEaseApi", {
+      restApiName: "TravelEase Backend Service",
+      defaultCorsPreflightOptions: {
+        allowOrigins: apigw.Cors.ALL_ORIGINS,
+        allowMethods: apigw.Cors.ALL_METHODS,
+      },
+    });
+
+    const submitResource = this.api.root.addResource("submit");
+    submitResource.addMethod("POST", new apigw.LambdaIntegration(formHandler));
+
+    new CfnOutput(this, "ApiEndpoint", {
+      value: this.api.url ?? "",
+    });
+
+    new CfnOutput(this, "QueueUrl", {
+      value: this.queue.queueUrl,
+    });
+
+    new CfnOutput(this, "TableName", {
+      value: this.table.tableName,
+    });
+
+    new CfnOutput(this, "NotificationTopicArn", {
+      value: this.notificationTopic.topicArn,
+    });
+
+    new CfnOutput(this, "SesConfigurationSetName", {
+      value: this.configurationSet.name ?? this.configurationSet.ref,
+    });
+  }
+}


### PR DESCRIPTION
## Summary
- add an SES email identity stack and wire it into the backend deployment
- provision an SNS topic with email subscription and SES configuration set for bounce notifications
- update the form handler Lambda to validate payloads, send SES emails, publish to SNS, and persist submissions

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690df345165c8330aa46d736652d4da0)